### PR TITLE
Pull request on third_parties.repos

### DIFF
--- a/third_parties.repos
+++ b/third_parties.repos
@@ -42,8 +42,17 @@ repositories:
   ThirdParty/tiago_description_calibration:
     type: git
     url: https://github.com/pal-robotics/tiago_description_calibration.git
+    version: foxy-devel
+  ThirdParty/tiago_moveit_config:
+    type: git
+    url: https://github.com/pal-robotics/tiago_moveit_config.git
+    version: humble-devel
+  ThirdParty/tiago_navigation:
+    type: git
+    url: https://github.com/pal-robotics/tiago_navigation.git
     version: humble-devel
   ThirdParty/Groot:
     type: git
     url: https://github.com/BehaviorTree/Groot.git
     version: master
+


### PR DESCRIPTION
On third_parties.repos:
1. Changed tiago_description_calibration version to foxy-devel due to branch humble-devel is not available on pal-robotics/tiago_description_calibration.
2. Added tiago_moveit_config and tiago_navigation to solve the error during rosdep install.